### PR TITLE
Add openSUSE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The script has been designed to automatically detect your operating system. Curr
 * Elementary OS
 * Antergos
 * Linuxmint
+* openSUSE
 
 ****For other distros, please see note at end of this README***
 


### PR DESCRIPTION
The initial goal of forking this _was_ to add openSUSE support, but
after looking through the source I see that you already supported it 😄 

This simply updates the README to include openSUSE in the list of
supported distros